### PR TITLE
Set project version constant and display at startup

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "greyscan"
-version = "0.1.0"
+version = {attr = "greyscan.__init__.__version__"}
 description = "Gray Bar Scanner for Image Files"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/src/greyscan/__init__.py
+++ b/src/greyscan/__init__.py
@@ -1,5 +1,7 @@
 """Gray Bar Scanner package."""
 
+__version__ = "0.0.1"
+
 __all__ = [
     "batch_scan_images",
     "scan_image_for_gray_bands",

--- a/src/greyscan/cli.py
+++ b/src/greyscan/cli.py
@@ -1,10 +1,13 @@
 import argparse
 from datetime import datetime
 
+from . import __version__
+
 
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Scan images for gray bars")
+    parser.add_argument("--version", action="version", version=f"%(prog)s {__version__}")
     parser.add_argument("path", help="Path to folder containing images")
     parser.add_argument(
         "--band-height",
@@ -48,6 +51,8 @@ def build_parser() -> argparse.ArgumentParser:
 def main(argv=None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
+
+    print(f"Greyscan {__version__}\n")
 
     if args.verbose:
         print(f"Starting scan in '{args.path}'...\n")


### PR DESCRIPTION
## Summary
- define `__version__` constant in `greyscan` package
- reference the constant from `pyproject.toml`
- print application version when running CLI
- add `--version` option to the CLI

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d070974cc8329a4aed5ae8cfcd1a4